### PR TITLE
Making devcontainer always use latest by default

### DIFF
--- a/src/dotnetaspire/devcontainer-feature.json
+++ b/src/dotnetaspire/devcontainer-feature.json
@@ -1,19 +1,19 @@
 {
     "id": "dotnetaspire",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "name": ".NET Aspire",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/dotnetaspire",
-    "description": "Installs .NET Aspire. See https://aka.ms/dotnetaspire",
+    "description": "Installs Aspire. See https://aka.ms/dotnetaspire",
     "options": {
         "version": {
             "type": "string",
             "proposals": [
                 "latest daily",
                 "latest",
-                "9.1",
+                "9.3",
             ],
-            "default": "9.1",
-            "description": "Select or enter a .NET Aspire version. Use 'latest' for the latest supported version, '9.1' for the 9.1 version, 'X.Y' or 'X.Y.Z' for a specific version, or 'latest-daily' for the latest unsupported build."
+            "default": "latest",
+            "description": "Select or enter an Aspire version. Use 'latest' for the latest supported version, '9.3' for the 9.3 version, 'X.Y' or 'X.Y.Z' for a specific version, or 'latest-daily' for the latest unsupported build."
         },
     },
     "customizations": {
@@ -35,7 +35,7 @@
     },
     "dependsOn": {
         "ghcr.io/devcontainers/features/dotnet": {
-            "version": "9.0"
+            "version": "latest"
         }
     }
 }


### PR DESCRIPTION
Noticed this earlier when making a new one. Latest is the move!