### PR TITLE
Update devcontainer-feature.json description to 9.3.1

### DIFF
--- a/src/dotnetaspire/devcontainer-feature.json
+++ b/src/dotnetaspire/devcontainer-feature.json
@@ -13,7 +13,7 @@
                 "9.3",
             ],
             "default": "latest",
-            "description": "Select or enter an Aspire version. Use 'latest' for the latest supported version, '9.3' for the 9.3 version, 'X.Y' or 'X.Y.Z' for a specific version, or 'latest-daily' for the latest unsupported build."
+            "description": "Select or enter an Aspire version. Use 'latest' for the latest supported version, '9.3.1' for the 9.3.1 version, 'X.Y' or 'X.Y.Z' for a specific version, or 'latest-daily' for the latest unsupported build."
         },
     },
     "customizations": {


### PR DESCRIPTION
This pull request makes a small update to the `src/dotnetaspire/devcontainer-feature.json` file. The change updates the description for selecting an Aspire version, replacing `9.3` with `9.3.1` to reflect the updated version.